### PR TITLE
Added an additional option to convert the given meta string to HTML

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -77,7 +77,12 @@
         if (options.tooltipFnc) {
           tooltipText = options.tooltipFnc(meta, value);
         } else {
-
+          if(options.metaIsHTML){
+            var txt = document.createElement("textarea");
+            txt.innerHTML = meta;
+            meta = txt.value;
+          }
+          
           meta = '<span class="chartist-tooltip-meta">' + meta + '</span>';
           value = '<span class="chartist-tooltip-value">' + value + '</span>';
 


### PR DESCRIPTION
This arises from (and solves) issue #45.

This adds support for an additional option (metaIsHTML). If passed in true, the plugin will convert the given meta string to dom elements before adding them. Useful for giving users more control over marking up and styling their tooltips.