### PR TITLE
Add css file to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "chartist-plugin-tooltip",
   "main": [
-    "./dist/chartist-plugin-tooltip.min.js"
+    "./dist/chartist-plugin-tooltip.min.js",
+    "./dist/chartist-plugin-tooltip.css"
   ],
   "dependencies": {
     "chartist": "~0.9.4"


### PR DESCRIPTION
At first look it's minor. But for me it is very important as far as I use **main-bower-files** for building project. It assembles all main files from bower_components.