### PR TITLE
Fix currency not being formatted

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -99,10 +99,10 @@
           }
 
           if (value) {
-            value = '<span class="chartist-tooltip-value">' + value + '</span>';
             if (options.currency) {
               value = options.currency + value.replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, "$1,");
             }
+            value = '<span class="chartist-tooltip-value">' + value + '</span>';
             tooltipText += value;
           }
         }


### PR DESCRIPTION
When currency is enabled,
`value.replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, "$1,");`
does not work because the value is already modified by
`value = '<span class="chartist-tooltip-value">' + value + '</span>';`

Sorry for opening a new pull request, I have no idea why GitHub decided to closed my PR when I force push.