### PR TITLE
Fix #35 Tooltip position does not adjust when in modal.

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -128,17 +128,22 @@
       });
 
       function setPosition(event) {
-        // For some reasons, on FF, we can't rely on event.offsetX and event.offsetY,
-        // that's why we prioritize event.layerX and event.layerY
-        // see https://github.com/gionkunz/chartist-js/issues/381
         height = height || $toolTip.offsetHeight;
         width = width || $toolTip.offsetWidth;
+        var offsetX = - width / 2 + options.tooltipOffset.x
+        var offsetY = - height + options.tooltipOffset.y;
+        
         if (!options.appendToBody) {
-          $toolTip.style.top = (event.layerY || event.offsetY) - height + options.tooltipOffset.y + 'px';
-          $toolTip.style.left = (event.layerX || event.offsetX) - width / 2 + options.tooltipOffset.x + 'px';
+          var box = $chart.getBoundingClientRect();
+          var left = event.pageX - box.left - window.pageXOffset ;
+          var top = event.pageY - box.top - window.pageYOffset ;
+
+          $toolTip.style.top = top + offsetY + 'px';
+          $toolTip.style.left = left + offsetX + 'px';
+          
         } else {
-          $toolTip.style.top = event.pageY - height  + options.tooltipOffset.y + 'px';
-          $toolTip.style.left = event.pageX - width / 2 + options.tooltipOffset.x + 'px';
+          $toolTip.style.top = event.pageY + offsetY + 'px';
+          $toolTip.style.left = event.pageX + offsetX + 'px';
         }
       }
     }

--- a/test/spec/spec-tooltip.js
+++ b/test/spec/spec-tooltip.js
@@ -73,13 +73,13 @@ describe('ctPointLabels', function () {
   });
 
   it('should set tooltip position', function() {
-    event.layerX = 100;
-    event.layerY = 200;
+    event.pageX = 100;
+    event.pageY = 200;
     listeners['mousemove'](event);
     expect(getTooltip().style.left).toMatch(/^\d+px$/);
     expect(getTooltip().style.top).toMatch(/^\d+px$/);
   });
-
+  
   it('should set additional class', function(){
     expect(hasClass(getTooltip(), 'foo')).toBe(true);
   });


### PR DESCRIPTION
This change fixes positioning issues for charts in a position:fixed container. The position is calculated by the chart's bounding rect, page and scroll position.
Tested: Windows: Chrome49, FF45, IE11