### PR TITLE
Currency format callback function

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -8,6 +8,7 @@
 
   var defaultOptions = {
     currency: undefined,
+    currencyFormatCallback: undefined,
     tooltipOffset: {
       x: 0,
       y: -20
@@ -131,7 +132,7 @@
         var offsetX = - width / 2 + options.tooltipOffset.x
         var offsetY = - height + options.tooltipOffset.y;
         var anchorX, anchorY;
-        
+
         if (!options.appendToBody) {
           var box = $chart.getBoundingClientRect();
           var left = event.pageX - box.left - window.pageXOffset ;

--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -99,7 +99,11 @@
 
           if (value) {
             if (options.currency) {
-              value = options.currency + value.replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, '$1,');
+              if (options.currencyFormatCallback != undefined) {
+                value = options.currencyFormatCallback(value, options);
+              } else {
+                value = options.currency + value.replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, '$1,');
+              }
             }
             value = '<span class="chartist-tooltip-value">' + value + '</span>';
             tooltipText += value;


### PR DESCRIPTION
I was unsatisfied with the currency format when i used the "currency" option. So i added the option "currencyFormatCallback", to pass an callback function which will do the format job because i'm working in an international context and have the need for different currency formats.

Example usage:

```javascript
Chartist.plugins.tooltip({
    currency: '€',
    currencyFormatCallback: function(num, options) {
        return parseFloat(num).toFixed(2).replace('.', ',').replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.') + ' ' + options.currency
    }
})
```
