### PR TITLE
Fixed positioning after content change

### DIFF
--- a/src/scripts/chartist-plugin-tooltip.js
+++ b/src/scripts/chartist-plugin-tooltip.js
@@ -112,12 +112,11 @@
 
         if(tooltipText) {
           $toolTip.innerHTML = tooltipText;
-          setPosition(event);
-          show($toolTip);
-
-          // Remember height and width to avoid wrong position in IE
+          // get and store new height
           height = $toolTip.offsetHeight;
           width = $toolTip.offsetWidth;
+          setPosition(event);
+          show($toolTip);
         }
       });
 


### PR DESCRIPTION
On first display of the message and after content size change the message was positioned incorrectly, as the memoized height and width would be taken for position calculation and only afterwards the new size would be retrieved (and that apparently only as IE fix).